### PR TITLE
2023.7.6

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,12 +8,6 @@ name: Publish Docker image
 on:
   release:
     types: [published]
-  push:
-    branches: [ main ]
-    # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   push_to_registry:

--- a/.github/workflows/ha-addon-builder.yaml
+++ b/.github/workflows/ha-addon-builder.yaml
@@ -11,8 +11,6 @@ on:
   pull_request:
     branches:
       - main
-  release:
-    types: [published]
 
 jobs:
   init:

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Mark Roberts <mark.roberts30@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@markxroberts/risco-lan-bridge": "^0.14.17",
+    "@markxroberts/risco-lan-bridge": "^0.14.28",
     "lodash": "^4.17.21",
     "mqtt": "^4.3.2",
     "winston": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Mark Roberts <mark.roberts30@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@markxroberts/risco-lan-bridge": "^0.14.27",
+    "@markxroberts/risco-lan-bridge": "^0.14.17",
     "lodash": "^4.17.21",
     "mqtt": "^4.3.2",
     "winston": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Mark Roberts <mark.roberts30@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@markxroberts/risco-lan-bridge": "^0.14.15",
+    "@markxroberts/risco-lan-bridge": "^0.14.17",
     "lodash": "^4.17.21",
     "mqtt": "^4.3.2",
     "winston": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Mark Roberts <mark.roberts30@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@markxroberts/risco-lan-bridge": "^0.14.17",
+    "@markxroberts/risco-lan-bridge": "^0.14.27",
     "lodash": "^4.17.21",
     "mqtt": "^4.3.2",
     "winston": "^3.3.3",

--- a/risco-mqtt-local-addon/Dockerfile
+++ b/risco-mqtt-local-addon/Dockerfile
@@ -1,2 +1,2 @@
-FROM markxroberts/risco-mqtt-local:2023.7.6-beta6
+FROM markxroberts/risco-mqtt-local:2023.7.6-beta9
 ENV RISCO_MQTT_HA_CONFIG_FILE="/config/risco-mqtt.json"

--- a/risco-mqtt-local-addon/Dockerfile
+++ b/risco-mqtt-local-addon/Dockerfile
@@ -1,2 +1,2 @@
-FROM markxroberts/risco-mqtt-local:2023.7.6-beta13
+FROM markxroberts/risco-mqtt-local:2023.7.6
 ENV RISCO_MQTT_HA_CONFIG_FILE="/config/risco-mqtt.json"

--- a/risco-mqtt-local-addon/Dockerfile
+++ b/risco-mqtt-local-addon/Dockerfile
@@ -1,2 +1,2 @@
-FROM markxroberts/risco-mqtt-local:2023.7.6-beta9
+FROM markxroberts/risco-mqtt-local:2023.7.6-beta10
 ENV RISCO_MQTT_HA_CONFIG_FILE="/config/risco-mqtt.json"

--- a/risco-mqtt-local-addon/Dockerfile
+++ b/risco-mqtt-local-addon/Dockerfile
@@ -1,2 +1,2 @@
-FROM markxroberts/risco-mqtt-local:2023.7.6-beta12
+FROM markxroberts/risco-mqtt-local:2023.7.6-beta13
 ENV RISCO_MQTT_HA_CONFIG_FILE="/config/risco-mqtt.json"

--- a/risco-mqtt-local-addon/Dockerfile
+++ b/risco-mqtt-local-addon/Dockerfile
@@ -1,2 +1,2 @@
-FROM markxroberts/risco-mqtt-local:2023.7.6-beta11
+FROM markxroberts/risco-mqtt-local:2023.7.6-beta12
 ENV RISCO_MQTT_HA_CONFIG_FILE="/config/risco-mqtt.json"

--- a/risco-mqtt-local-addon/Dockerfile
+++ b/risco-mqtt-local-addon/Dockerfile
@@ -1,2 +1,2 @@
-FROM markxroberts/risco-mqtt-local:2023.7.6-beta10
+FROM markxroberts/risco-mqtt-local:2023.7.6-beta11
 ENV RISCO_MQTT_HA_CONFIG_FILE="/config/risco-mqtt.json"

--- a/src/lib/risco-mqtt-local.ts
+++ b/src/lib/risco-mqtt-local.ts
@@ -164,8 +164,6 @@ const CONFIG_DEFAULTS: RiscoMQTTConfig = {
 export function riscoMqttHomeAssistant(userConfig: RiscoMQTTConfig) {
 
   const config = merge(CONFIG_DEFAULTS, userConfig);
-  const panel = new RiscoPanel(config.panel);
-  let alarmMapping: PartitionArmingModes[] = [];
 
   let format = combine(
     timestamp({
@@ -211,6 +209,9 @@ export function riscoMqttHomeAssistant(userConfig: RiscoMQTTConfig) {
   let haonline = false;
 
   if (!config.mqtt?.url) throw new Error('mqtt url option is required');
+
+  const panel = new RiscoPanel(config.panel);
+  let alarmMapping: PartitionArmingModes[] = [];
 
   panel.on('SystemInitComplete', () => {
     panel.riscoComm.tcpSocket.on('Disconnected', () => {

--- a/src/lib/risco-mqtt-local.ts
+++ b/src/lib/risco-mqtt-local.ts
@@ -338,6 +338,7 @@ export function riscoMqttHomeAssistant(userConfig: RiscoMQTTConfig) {
         }
       } else {
         logger.info('Home Assistant has gone offline');
+        haonline = false;
       }
     }
   });
@@ -564,15 +565,12 @@ export function riscoMqttHomeAssistant(userConfig: RiscoMQTTConfig) {
     mqttClient.publish(`${config.risco_node_id}/alarm/status`, 'online', {
       qos: 1, retain: true,
     });
-    mqttClient.publish(`${config.risco_node_id}/alarm/panelstatus`, '1', {
-      qos: 1, retain: true,
-    });
     logger.verbose('[Panel => MQTT] Published alarm online');
   }
 
   function publishOffline() {
     if (mqttReady) {
-      mqttClient.publish(`${config.risco_node_id}/alarm/panelstatus`, '0', {
+      mqttClient.publish(`${config.risco_node_id}/alarm/status`, 'offline', {
         qos: 1, retain: true,
       });
       logger.verbose('[Panel => MQTT] Published alarm offline');

--- a/src/lib/risco-mqtt-local.ts
+++ b/src/lib/risco-mqtt-local.ts
@@ -1097,7 +1097,7 @@ export function riscoMqttHomeAssistant(userConfig: RiscoMQTTConfig) {
           logger.info(`${granted[0].topic} was subscribed`);
         }
       });
-      panel.riscoComm.on('Clock', publishOnline);
+      panel.riscoComm.on('Clock', (data) => {publishOnline});
       panel.riscoComm.tcpSocket.on('Disconnected', (data) => {publishOffline()});
       panel.riscoComm.on('PanelCommReady', (data) => {publishOnline()});
       panel.riscoComm.tcpSocket.on('CloudConnected', () => {publishCloudStatus(true)});


### PR DESCRIPTION
Group arming.
Removed panel and cloud connection sensors as these don't update.
If no HA online message received, baseline states automatically published after delay.
New version of risco-lan-bridge.  Extra sensors removed.  Extended clock timeout leads to socket reinitialisation.