### PR TITLE
New risco-lan-bridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markxroberts/risco-mqtt-local",
-  "version": "2023.11.1",
+  "version": "2023.12.0",
   "description": "Node Risco Mqtt using local panel API",
   "main": "dist/main.js",
   "types": "dist/lib/index.d.ts",
@@ -25,7 +25,7 @@
   "author": "Mark Roberts <mark.roberts30@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@markxroberts/risco-lan-bridge": "^0.15.2",
+    "@markxroberts/risco-lan-bridge": "^0.15.4",
     "lodash": "^4.17.21",
     "mqtt": "^4.3.2",
     "winston": "^3.3.3",

--- a/risco-mqtt-local-addon/Dockerfile
+++ b/risco-mqtt-local-addon/Dockerfile
@@ -1,2 +1,2 @@
-FROM markxroberts/risco-mqtt-local:2023.11.1
+FROM markxroberts/risco-mqtt-local:2023.12.0
 ENV RISCO_MQTT_HA_CONFIG_FILE="/config/risco-mqtt.json"

--- a/risco-mqtt-local-addon/config.yaml
+++ b/risco-mqtt-local-addon/config.yaml
@@ -1,5 +1,5 @@
 name: Risco local MQTT
-version: 2023.11.1
+version: 2023.12.0
 slug: risco-mqtt-local-addon
 description: Risco alarm HA integration using local TCP communication and MQTT
 url: https://ghcr.io/markxroberts/risco-mqtt-local


### PR DESCRIPTION
Two new options for configuration file:
- cloudSocketTimeout: number (default 12000 [ms])
- cloudSocketKeepAlive: boolean (default false)