### PR TITLE
Alarm code ignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markxroberts/risco-mqtt-local",
-  "version": "2024.6.0",
+  "version": "2024.6.1",
   "description": "Node Risco Mqtt using local panel API",
   "main": "dist/main.js",
   "types": "dist/lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markxroberts/risco-mqtt-local",
-  "version": "2024.5.0",
+  "version": "2024.6.0",
   "description": "Node Risco Mqtt using local panel API",
   "main": "dist/main.js",
   "types": "dist/lib/index.d.ts",

--- a/risco-mqtt-local-addon/Dockerfile
+++ b/risco-mqtt-local-addon/Dockerfile
@@ -1,2 +1,2 @@
-FROM markxroberts/risco-mqtt-local:2024.5.0
+FROM markxroberts/risco-mqtt-local:2024.6.0
 ENV RISCO_MQTT_HA_CONFIG_FILE="/config/risco-mqtt.json"

--- a/risco-mqtt-local-addon/Dockerfile
+++ b/risco-mqtt-local-addon/Dockerfile
@@ -1,2 +1,2 @@
-FROM markxroberts/risco-mqtt-local:2024.6.0
+FROM markxroberts/risco-mqtt-local:2024.6.1
 ENV RISCO_MQTT_HA_CONFIG_FILE="/config/risco-mqtt.json"

--- a/risco-mqtt-local-addon/config.yaml
+++ b/risco-mqtt-local-addon/config.yaml
@@ -1,5 +1,5 @@
 name: Risco local MQTT
-version: 2024.6.0
+version: 2024.6.1
 slug: risco-mqtt-local-addon
 description: Risco alarm HA integration using local TCP communication and MQTT
 url: https://ghcr.io/markxroberts/risco-mqtt-local

--- a/risco-mqtt-local-addon/config.yaml
+++ b/risco-mqtt-local-addon/config.yaml
@@ -1,5 +1,5 @@
 name: Risco local MQTT
-version: 2023.12.0
+version: 2024.6.0
 slug: risco-mqtt-local-addon
 description: Risco alarm HA integration using local TCP communication and MQTT
 url: https://ghcr.io/markxroberts/risco-mqtt-local

--- a/src/lib/risco-mqtt-local.ts
+++ b/src/lib/risco-mqtt-local.ts
@@ -934,7 +934,8 @@ export function riscoMqttHomeAssistant(userConfig: RiscoMQTTConfig) {
         payload_arm_night: armingConfig.armed_night,
         payload_arm_vacation: armingConfig.armed_vacation,
         payload_arm_custom_bypass: armingConfig.armed_custom_bypass,
-        code_alarm_required: false,
+        code_arm_required: false,
+        code_disarm_required: false,
         device: getDeviceInfo(),
         command_topic: `${config.risco_mqtt_topic}/alarm/partition/${partition.Id}/set`,
       };

--- a/src/lib/risco-mqtt-local.ts
+++ b/src/lib/risco-mqtt-local.ts
@@ -934,6 +934,7 @@ export function riscoMqttHomeAssistant(userConfig: RiscoMQTTConfig) {
         payload_arm_night: armingConfig.armed_night,
         payload_arm_vacation: armingConfig.armed_vacation,
         payload_arm_custom_bypass: armingConfig.armed_custom_bypass,
+        code_alarm_required: false,
         device: getDeviceInfo(),
         command_topic: `${config.risco_mqtt_topic}/alarm/partition/${partition.Id}/set`,
       };


### PR DESCRIPTION
Update to work with HA 2024.6.0 and not require alarm code to arm or disarm.